### PR TITLE
Expose crash code and log when container exited early.

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -113,7 +113,8 @@ def test_failed_to_start_container(_docker_client, pytester):
     result = pytester.runpytest()
     result.assert_outcomes(errors=1)
     result.stdout.re_match_lines([
-        r".*container test-pg-database-container-not-starting exited with code \d+.*"
+        r".*container test-pg-database-container-not-starting exited with code \d+.*",
+        r".*Error: Database is uninitialized and superuser password is not specified.*",
     ])
 
     c = _docker_client.containers.get("test-pg-database-container-not-starting")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -113,7 +113,7 @@ def test_failed_to_start_container(_docker_client, pytester):
     result = pytester.runpytest()
     result.assert_outcomes(errors=1)
     result.stdout.re_match_lines([
-        ".*container test-pg-database-container-not-starting failed to start: status 'exited' / expected status 'running'",
+        r".*container test-pg-database-container-not-starting exited with code \d+.*"
     ])
 
     c = _docker_client.containers.get("test-pg-database-container-not-starting")


### PR DESCRIPTION
Without this change, I can't tell whether the container is blocking during startup or failed to start, because the crash log is swallowed.